### PR TITLE
fork: moving fork handling from behind the experiment

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -725,7 +725,9 @@ void PollPoller::Close() {
 
 #ifdef GRPC_ENABLE_FORK_SUPPORT
 void PollPoller::HandleForkInChild() {
-  posix_interface().AdvanceGeneration();
+  if (grpc_core::IsEventEngineForkEnabled()) {
+    posix_interface().AdvanceGeneration();
+  }
   PollEventHandle* handle;
   {
     grpc_core::MutexLock lock(&mu_);

--- a/src/core/lib/event_engine/thread_pool/thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/thread_pool.h
@@ -35,8 +35,14 @@ class ThreadPool {
   virtual void Run(absl::AnyInvocable<void()> callback) = 0;
   virtual void Run(EventEngine::Closure* closure) = 0;
 
+#if GRPC_ENABLE_FORK_SUPPORT
   virtual void PrepareFork() = 0;
   virtual void PostFork() = 0;
+
+  virtual void PreventFork() = 0;
+  virtual void AllowFork() = 0;
+
+#endif  // GRPC_ENABLE_FORK_SUPPORT
 };
 
 // Creates a default thread pool.

--- a/src/python/grpcio_tests/tests/fork/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/fork/BUILD.bazel
@@ -28,8 +28,7 @@ py_test(
     name = "fork_test",
     srcs = glob(["*.py"]),
     # TODO(yijiem): remove this to test EventEngine fork support
-    # TODO(eostroukhov): event_engine_fork experiment needs to be enabled for this test
-    env = {"GRPC_EXPERIMENTS": "-event_engine_client,event_engine_fork"},
+    env = {"GRPC_EXPERIMENTS": "-event_engine_client"},
     imports = ["../.."],
     main = "_fork_interop_test.py",
     python_version = "PY3",

--- a/test/core/event_engine/thread_pool_test.cc
+++ b/test/core/event_engine/thread_pool_test.cc
@@ -65,6 +65,8 @@ TYPED_TEST(ThreadPoolTest, CanDestroyInsideClosure) {
   n.WaitForNotification();
 }
 
+#if GRPC_ENABLE_FORK_SUPPORT
+
 TYPED_TEST(ThreadPoolTest, CanSurviveFork) {
   TypeParam p(8);
   grpc_core::Notification inner_closure_ran;
@@ -169,6 +171,8 @@ TYPED_TEST(ThreadPoolTest, StartQuiesceRaceStressTest) {
     t2.Join();
   }
 }
+
+#endif  // GRPC_ENABLE_FORK_SUPPORT
 
 void ScheduleSelf(ThreadPool* p) {
   p->Run([p] { ScheduleSelf(p); });

--- a/test/cpp/end2end/client_fork_test.cc
+++ b/test/cpp/end2end/client_fork_test.cc
@@ -127,11 +127,11 @@ std::pair<std::string, std::string> DoExchangeAsync(absl::string_view label,
       EchoTestService::NewStub(CreateChannel(addr));
   EchoClientBidiReactor reactor;
   stub->async()->BidiStream(&context, &reactor);
-  request.set_message(absl::Substitute("Hello again from [$0]", getpid()));
+  request.set_message(absl::Substitute("Hello again from $0", getpid()));
   reactor.StartWrite(&request);
   reactor.StartRead(&response);
   reactor.StartCall();
-  VLOG(2) << label << " Doing the call";
+  VLOG(2).WithThreadID(getpid()) << label << " Doing the call";
   reactor.WaitReadWriteDone();
   reactor.StartWritesDone();
   reactor.WaitAllDone();


### PR DESCRIPTION
- Moves fork handling from behind the event_engine_fork experiment
  - No experiment (parity with original fork implementation):
    - Thread pool and timer manager will go through the fork as expected
    - Epoll poller fd will be recreated in the child
    - EventHandles are closed in the child process.
  - Behind experiment (new functionality):
    - File descriptors are tracked in the collection
    - FD generation is tracked and checked on every Posix call.
    - AresResolver is reset on fork
- Fixes to address race between PosixEngine destructor and fork
  handling.
  - Thread pool will properly handle fork even if the parent PosixEngine
    instance entered the destructor before the fork call
  - Thread pool fork handler will wait for the parent event engine
    destructor to finish before shutting down threads.